### PR TITLE
Add prototype plugin

### DIFF
--- a/flake8p/plugin.py
+++ b/flake8p/plugin.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List
+import configparser
+
+import flake8.options.config
+
+from .util import monkeypatch
+
+class FlakeConfigToml:
+    def __init__(self, tree):
+        pass
+
+    def __iter__(self):
+        raise StopIteration()
+
+    def run(self, *args) -> List[Any]:
+        return []
+
+    def add_options(self, *args):
+        monkeypatch()

--- a/flake8p/plugin.py
+++ b/flake8p/plugin.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from .util import monkeypatch
 

--- a/flake8p/plugin.py
+++ b/flake8p/plugin.py
@@ -1,8 +1,3 @@
-from typing import Any, Dict, List
-import configparser
-
-import flake8.options.config
-
 from .util import monkeypatch
 
 class FlakeConfigToml:

--- a/flake8p/plugin.py
+++ b/flake8p/plugin.py
@@ -1,6 +1,14 @@
+from typing import List
+
 from .util import monkeypatch
 
 class FlakeConfigToml:
+    # pylint: disable=no-self-use
+    """
+    Flake8 plugin to load a `pyproject.toml` file from the current directory.
+    """
+    # Pylint warning disabled because this is a plugin and these methods
+    # need to be present...but we don't need to use `self`.
     def __init__(self, tree):
         pass
 

--- a/flake8p/util.py
+++ b/flake8p/util.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Any, Dict, List, Optional
+from typing import Any, Dict, Optional, Tuple
 from pathlib import Path
 import configparser
 import sys
@@ -35,7 +35,7 @@ def normalize_from_toml(settings: Dict[str, Any]) -> Dict[str, Any]:
         output[key] = value
     return {"flake8": output}
 
-def find_and_load_toml_file(_path: Optional[str]=None) -> Tuple[Optional[Path], Dict[str, Any]]:
+def find_and_load_toml_file(_path: Optional[str] = None) -> Tuple[Optional[Path], Dict[str, Any]]:
     if _path:
         path = Path(_path).resolve()
     else:

--- a/flake8p/util.py
+++ b/flake8p/util.py
@@ -1,0 +1,68 @@
+from typing import Tuple, Any, Dict, List, Optional
+from pathlib import Path
+import configparser
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib as toml
+else:
+    import tomli as toml
+
+import flake8.options.config
+
+def _stat_key(p: Path) -> Tuple[int, int]:
+    st = p.stat()
+    return st.st_ino, st.st_dev
+
+def load_flake8_from_toml(filename: Path) -> Dict[str, Any]:
+    try:
+        with filename.open('rb') as f:
+            settings = toml.load(f)
+        if 'tool' in settings and 'flake8' in settings['tool']:
+            return {"flake8": settings["tool"]["flake8"]}
+        else:
+            return {}
+    except Exception:
+        return {}
+
+def normalize_from_toml(settings: Dict[str, Any]) -> Dict[str, Any]:
+    output = {}
+    for key, value in settings["flake8"].items():
+        if isinstance(value, (bool, int, float)):
+            value = str(value)
+        elif isinstance(value, list):
+            value = ",".join(str(x) for x in value)
+        output[key] = value
+    return {"flake8": output}
+
+def find_and_load_toml_file(_path: Optional[str]=None) -> Tuple[Optional[Path], Dict[str, Any]]:
+    if _path:
+        path = Path(_path).resolve()
+    else:
+        path = Path(".").resolve()
+
+    cfg_path = path / "pyproject.toml"
+    if cfg_path.exists():
+        cfg = load_flake8_from_toml(cfg_path)
+        if cfg:
+            return cfg_path, cfg
+
+    # did not find any configuration file
+    return None, {}
+
+def monkeypatch():
+    flake8_parse_config = flake8.options.config.parse_config
+    flake8_option_manager = flake8.options.config.OptionManager
+
+    def parse_config(
+        option_manager: flake8_option_manager,
+        cfg: configparser.RawConfigParser,
+        cfg_dir: str,
+    ) -> Dict[str, Any]:
+        _cfg_path, loaded_toml = find_and_load_toml_file()
+        if loaded_toml:
+            normalized = normalize_from_toml(loaded_toml)
+            cfg.read_dict(normalized)
+        return flake8_parse_config(option_manager, cfg, cfg_dir)
+
+    flake8.options.config.parse_config = parse_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 [project.scripts]
 flake8p = 'flake8p:main'
 
+[project.entry-points."flake8.extension"]
+CFG999 = "flake8p.plugin:FlakeConfigToml"
+
 [project.optional-dependencies]
 test = ['pyTest', 'pyTest-cov']
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,3 +62,48 @@ def test_empty_pyproject():
 def test_empty_tool_section():
     output = capture(['flake8p'], 'empty_tool_section')
     assert not output
+
+
+def test_plugin_config_pyproject():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_pyproject')
+    assert output == expected
+
+
+def test_plugin_config_flake8():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_flake8')
+    assert output == expected
+
+
+def test_plugin_config_setup():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_setup')
+    assert output == expected
+
+
+def test_plugin_config_tox():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_tox')
+    assert output == expected
+
+
+def test_plugin_config_mixed():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_mixed')
+    assert output == expected
+
+
+def test_plugin_run_main():
+    output = capture([python, '-m', 'flake8', '--require-plugins', 'flake8-pyproject', 'module.py'], 'config_mixed')
+    assert output == expected
+
+
+def test_plugin_empty_folder():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject'], 'empty_folder')
+    assert not output
+
+
+def test_plugin_empty_pyproject():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject'], 'empty_pyproject')
+    assert not output
+
+
+def test_plugin_empty_tool_section():
+    output = capture(['flake8', '--require-plugins', 'flake8-pyproject'], 'empty_tool_section')
+    assert not output


### PR DESCRIPTION
It's rather difficult to modify `flake8` configuration before plugins are loaded...at least as part of the standard configuration-loading process, so some monkeypatching was required...

Some work seems to be in progress on actually providing a plugin interface for configuration changes (see https://github.com/PyCQA/flake8/blob/main/src/flake8/options/config.py#L88, refactor ~9 months ago), but I couldn't find any GitHub issues tracking the actual addition of a `flake8.configuration` plugin type, so this uses `flake8.extension` (with a name of `CFG99`, which hopefully won't have any plugin name collisions).

I did test the initial plugin code with a simpler project, using setuptools, and it worked, but then I refactored to unify with what was here and add the plugin.

The updated code also traverses the filesystem to attempt to locate `pyproject.toml` in a parent directory, similar to `flake8`, though obviously it would have trouble with _nested_ projects.

This PR should resolve #5 via autoconfiguring as a plugin, and should also address #7 due to the refactor / new find-file logic.