### PR TITLE
Add command-line option for custom config file (#11)

### DIFF
--- a/flake8p/hook.py
+++ b/flake8p/hook.py
@@ -34,13 +34,8 @@ def parse_config(option_manager, cfg, cfg_dir):
     args = vars(option_manager.parser.parse_args())
     custom_config_file = args.get('pyproject_file')
 
-    # absolute path
-    if custom_config_file and custom_config_file.startswith('/'):
+    if custom_config_file:
         file = Path(custom_config_file)
-    # relative path
-    elif custom_config_file:
-        file = Path.cwd() / custom_config_file
-    # default
     else:
         file = Path.cwd() / 'pyproject.toml'
 

--- a/flake8p/hook.py
+++ b/flake8p/hook.py
@@ -1,4 +1,4 @@
-﻿"""Hooks TOML parser into Flake8."""
+"""Hooks TOML parser into Flake8."""
 
 ########################################
 # Imports                              #
@@ -31,7 +31,19 @@ def parse_config(option_manager, cfg, cfg_dir):
     anything that may have been read from whatever other configuration
     file and read the `tool.flake8` section in `pyproject.toml` instead.
     """
-    file = Path.cwd()/'pyproject.toml'
+    args = vars(option_manager.parser.parse_args())
+    custom_config_file = args.get('pyproject_file')
+
+    # absolute path
+    if custom_config_file and custom_config_file.startswith('/'):
+        file = Path(custom_config_file)
+    # relative path
+    elif custom_config_file:
+        file = Path.cwd() / custom_config_file
+    # default
+    else:
+        file = Path.cwd() / 'pyproject.toml'
+
     if file.exists():
         with file.open('rb') as stream:
             pyproject = toml.load(stream)
@@ -44,6 +56,9 @@ def parse_config(option_manager, cfg, cfg_dir):
                     value = str(value)
                 parser.set(section, key, value)
             (cfg, cfg_dir) = (parser, str(file.resolve().parent))
+    elif custom_config_file:
+        raise FileNotFoundError
+
     return flake8_parse_config(option_manager, cfg, cfg_dir)
 
 
@@ -54,8 +69,20 @@ def parse_config(option_manager, cfg, cfg_dir):
 class Plugin:
     """Installs the hook when called via `flake8` itself."""
 
-    def add_options(self):
+    @classmethod
+    def add_options(cls, parser):
         flake8.options.config.parse_config = parse_config
+
+        # Adding pyproject file option
+        parser.add_option(
+            '--pyproject-file',
+            metavar='PYPROJECT_TOML',
+            default=None,
+            action='store',
+            parse_from_config=True,
+            help="Path to TOML configuration file (overrides the "
+            "default 'pyproject.toml'",
+        )
 
 
 ########################################

--- a/tests/fixtures/config_custom_file/flake8.toml
+++ b/tests/fixtures/config_custom_file/flake8.toml
@@ -1,0 +1,8 @@
+[tool.flake8]
+ignore = [
+    'E231',        # Missing whitespace after ',', ';', or ':'.
+    'E241',        # Multiple spaces after ','.
+]
+per-file-ignores = ['module.py:F401']
+max-line-length = 70
+count = true

--- a/tests/fixtures/config_custom_file/module.py
+++ b/tests/fixtures/config_custom_file/module.py
@@ -1,0 +1,6 @@
+﻿"""This line is 77 characters long, less than the default max-line-length."""
+
+import foo
+
+missing_space   = (None,None)
+multiple_spaces = (None, None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,9 +75,20 @@ def test_run_main(command):
 
 
 @mark.parametrize('command', ['flake8', 'flake8p'])
-def test_custom_file_target(command):
+def test_custom_file_target_relative_path(command):
     output = capture(
         [command, '--pyproject-file=flake8.toml', 'module.py'],
-        'config_custom_file'
+        'config_custom_file',
+    )
+    assert output == expected
+
+
+@mark.parametrize('command', ['flake8', 'flake8p'])
+def test_custom_file_target_absolut_path(command):
+    fixture = 'config_custom_file'
+    file_path  = Path(__file__).parent/'fixtures'/fixture/'flake8.toml'
+    output = capture(
+        [command, '--pyproject-file', file_path, 'module.py'],
+        fixture,
     )
     assert output == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,10 @@
 ﻿"""Integration tests for the package."""
 
-from subprocess import run, PIPE
 from pathlib import Path
+from subprocess import PIPE, run
 from sys import executable as python
-from pytest import mark
 
+from pytest import mark
 
 expected = r"""
 module.py:1:71: E501 line too long (77 > 70 characters)
@@ -71,4 +71,13 @@ def test_empty_tool_section(command):
 @mark.parametrize('command', ['flake8', 'flake8p'])
 def test_run_main(command):
     output = capture([python, '-m', command, 'module.py'], 'config_mixed')
+    assert output == expected
+
+
+@mark.parametrize('command', ['flake8', 'flake8p'])
+def test_custom_file_target(command):
+    output = capture(
+        [command, '--pyproject-file=flake8.toml', 'module.py'],
+        'config_custom_file'
+    )
     assert output == expected


### PR DESCRIPTION
## Changes
Add a separate CLI option called `--pyproject-file`, based on the way [flake8-black](https://github.com/peterjc/flake8-black/blob/master/flake8_black.py#L133) handles the same issue, ie config file type not being supported by flake8 in the first place.

### Open questions/issues
* Is the config option aptly named? Should it be named something else?
* The config option completely ignores other config files, no thoughts on having it work together with a `tox.ini` or a in-directory `pyproject.toml` has been considered.

### Testing
* Added unit tests to see that it works as expected
* Running locally in a monorepo to see that VSCode does in fact get the config from a subdirectory