### PR TITLE
Drop Python 3.6, 3.7, and 3.8 support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -95,7 +95,7 @@ here is installed as well. The pre-commit configuration, in
 `.pre-commit-config.yaml`, would then look like so:
 ```yaml
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 7.2.0
   hooks:
     - id: flake8
       additional_dependencies: [Flake8-pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@ classifiers = [
 ]
 readme = 'PyPI.md'
 dynamic = ['version', 'description']
-requires-python = '>= 3.6'
+requires-python = '>= 3.9'
 dependencies = [
-    'Flake8 >= 5',
+    'Flake8 >= 7.2.0',
     'TOMLi; python_version < "3.11"',
-    'TOMLi < 2; python_version < "3.7"',
 ]
 
 [project.optional-dependencies]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,8 +17,7 @@ def capture(command, folder):
     if isinstance(folder, str):
         folder = Path(__file__).parent/'fixtures'/folder
     process = run(command, stdout=PIPE, stderr=STDOUT,
-                  universal_newlines=True, cwd=folder)
-    # From Python 3.7 on, use `text=True` instead of `universal newlines`.
+                  text=True, cwd=folder)
     return process.stdout.strip()
 
 


### PR DESCRIPTION
In addition:

* Drop support for old flake8 versions
* Drop an old tomli dependency
* Update a subprocess invocation

Thanks for your work on this project!